### PR TITLE
CND Calibration suite v1.2.0

### DIFF
--- a/src/main/java/org/jlab/calib/services/cnd/CNDCalibration.java
+++ b/src/main/java/org/jlab/calib/services/cnd/CNDCalibration.java
@@ -77,8 +77,6 @@ public class CNDCalibration implements IDataEventListener, ActionListener,
 CalibrationConstantsListener, DetectorListener,
 ChangeListener {
 
-// pull test
-
 	// main panel
 	JPanel          pane         = null;
 	JFrame  innerConfigFrame = new JFrame("Configure CND calibration settings");

--- a/src/main/java/org/jlab/calib/services/cnd/CNDCalibration.java
+++ b/src/main/java/org/jlab/calib/services/cnd/CNDCalibration.java
@@ -1058,7 +1058,7 @@ ChangeListener {
 		Panel.add(intro1,c1);
 		c1.gridx = 0;
 		c1.gridy = 4;
-		JLabel intro2= new JLabel("- In \"Select Steps\" choose the calibration you want to perform");
+		JLabel intro2= new JLabel("- In \"Select Step\" choose the calibration you want to perform");
 		Panel.add(intro2,c1);
 		c1.gridx = 0;
 		c1.gridy = 5;
@@ -1066,7 +1066,7 @@ ChangeListener {
 		Panel.add(intro3,c1);
 		c1.gridx = 0;
 		c1.gridy = 6;
-		JLabel intro4= new JLabel("- In \"Tracking options\" add some cuts on the match CVT tracks. WARNING these cuts are used for every calibration step.");
+		JLabel intro4= new JLabel("- In \"Tracking / General\" add some cuts on the match CVT tracks. WARNING these cuts are used for every calibration step.");
 		Panel.add(intro4,c1);
 		c1.gridx = 0;
 		c1.gridy = 7;
@@ -1131,7 +1131,7 @@ ChangeListener {
 
 		
 		
-		configPane.add("Select steps", stepOuterPanel);    
+		configPane.add("Select Step", stepOuterPanel);    
 
 		// Previous calibration values
 		JPanel confOuterPanel = new JPanel(new BorderLayout());
@@ -1161,6 +1161,10 @@ ChangeListener {
 			confPanel.add(engPanels[i-2]);
 		}
 
+		/* YOU ARE HERE!
+		 * PLAY AROUND WITH THIS LINE FROM CNDPrevConfigPanel:
+		 * this.setBorder(BorderFactory.createTitledBorder(engine.stepName))
+		 * CAN THIS BE USED TO MANUALLY SET THE LABLES ON THESE BORDERS? */
 		
 		//    Previously:
 		//        for (int i=3; i< engines.length; i++) {
@@ -1172,7 +1176,7 @@ ChangeListener {
 		confOuterPanel.add(confPanel, BorderLayout.NORTH);
 		confOuterPanel.add(butPage2, BorderLayout.SOUTH);
 
-		configPane.add("Previous calibration values", confOuterPanel);
+		configPane.add("Previous Calibration Values", confOuterPanel);
 
 		// Tracking options
 		JPanel trOuterPanel = new JPanel(new BorderLayout());
@@ -1443,10 +1447,10 @@ ChangeListener {
 
 		JPanel butPage6 = new configButtonPanel(this, true, "Next");
 		effVOuterPanel.add(butPage6, BorderLayout.SOUTH);
-		configPane.add("Effective Velocity", effVOuterPanel);  
+		configPane.add("Effective Velocity, Uturn-TimeLoss & Adjusted LR-Offset", effVOuterPanel);  
 
-
-		// ut options
+//Suppress tabs for uturn' and Attenuation. -- PN
+/*		// ut options
 		JPanel utOuterPanel = new JPanel(new BorderLayout());
 		JPanel utPanel = new JPanel(new GridBagLayout());
 		utOuterPanel.add(utPanel, BorderLayout.NORTH);
@@ -1593,7 +1597,7 @@ ChangeListener {
 		JPanel butPage8= new configButtonPanel(this, true, "Next");
 		attOuterPanel.add(butPage8, BorderLayout.SOUTH);
 		configPane.add("Attenuation", attOuterPanel); 
-
+*/                                                                    //Suppress tabs for uturn' and Attenuation. -- PN
 
 		//LR offset
 		JPanel timeOuterPanel = new JPanel(new BorderLayout());
@@ -1627,7 +1631,7 @@ ChangeListener {
 
 		JPanel butPagetime = new configButtonPanel(this, true, "Next");
 		timeOuterPanel.add(butPagetime, BorderLayout.SOUTH);
-		configPane.add("Global time Offset", timeOuterPanel);    
+		configPane.add("Global TimeOffset", timeOuterPanel);    
 
 
 
@@ -1727,7 +1731,7 @@ ChangeListener {
 
 		JPanel butPage9 = new configButtonPanel(this, true, "Finish");        
 		energyOuterPanel.add(butPage9, BorderLayout.SOUTH);
-		configPane.add("Energy", energyOuterPanel);
+		configPane.add("Attenuation & Energy", energyOuterPanel);
 
 
 

--- a/src/main/java/org/jlab/calib/services/cnd/CNDCalibration.java
+++ b/src/main/java/org/jlab/calib/services/cnd/CNDCalibration.java
@@ -1090,7 +1090,7 @@ ChangeListener {
 
 		int gridy=0;
 		for (int i=0; i< engines.length; i++) {
-			if(i== HV || i== TIME_OFFSETS_RF || i== TDC_CONV )continue;
+			if(i== HV || i== TIME_OFFSETS_RF || i== TDC_CONV || i== UTURN_TLOSS || i== ATTENUATION)continue; //added exceptions for attenuation and LR_offset --PN
 				c.gridx = 0; c.gridy = gridy;
 				gridy++;
 				c.anchor = c.WEST;

--- a/src/main/java/org/jlab/calib/services/cnd/CNDCalibration.java
+++ b/src/main/java/org/jlab/calib/services/cnd/CNDCalibration.java
@@ -77,6 +77,8 @@ public class CNDCalibration implements IDataEventListener, ActionListener,
 CalibrationConstantsListener, DetectorListener,
 ChangeListener {
 
+// pull test
+
 	// main panel
 	JPanel          pane         = null;
 	JFrame  innerConfigFrame = new JFrame("Configure CND calibration settings");

--- a/src/main/java/org/jlab/calib/services/cnd/CNDCalibration.java
+++ b/src/main/java/org/jlab/calib/services/cnd/CNDCalibration.java
@@ -1158,13 +1158,19 @@ ChangeListener {
 
 		for (int i=2; i< 5; i++) {
 			engPanels[i-2] = new CNDPrevConfigPanel(engines[i]);
+			// Override the Prev.Calib titles with more instructive labled after changing engine names --PN
+			if (i-2 == 0) {
+				engPanels[i-2].setBorder(BorderFactory.createTitledBorder("TimeOffset_LR [Adj. LR-Offset for Global TimeOffset step]"));
+			}
+			if (i-2 == 1) {
+				engPanels[i-2].setBorder(BorderFactory.createTitledBorder("Effective Velocity"));
+			}
+			if (i-2 == 2) {
+				engPanels[i-2].setBorder(BorderFactory.createTitledBorder("Adjusted LR-Offset / Uturn-TimeLoss"));
+			}
 			confPanel.add(engPanels[i-2]);
-		}
 
-		/* YOU ARE HERE!
-		 * PLAY AROUND WITH THIS LINE FROM CNDPrevConfigPanel:
-		 * this.setBorder(BorderFactory.createTitledBorder(engine.stepName))
-		 * CAN THIS BE USED TO MANUALLY SET THE LABLES ON THESE BORDERS? */
+		}
 		
 		//    Previously:
 		//        for (int i=3; i< engines.length; i++) {

--- a/src/main/java/org/jlab/calib/services/cnd/CNDCalibrationEngine.java
+++ b/src/main/java/org/jlab/calib/services/cnd/CNDCalibrationEngine.java
@@ -64,7 +64,8 @@ public class CNDCalibrationEngine extends CalibrationEngine {
 	public String stepName = "Unknown";
 	public String fileNamePrefix = "Unknown";
 	public String filename = "Unknown.txt";
-
+	public String fileNamePrefix2 = "Unknown"; //--PN
+	public String filename2 = "Unknown.txt"; // --PN
 	// configuration
 	public int calDBSource = 0;
 	public static final int CAL_DEFAULT = 0;
@@ -346,6 +347,36 @@ public class CNDCalibrationEngine extends CalibrationEngine {
 		return filePrefix + "." + newFileNum + ".txt";
 	}
 
+	//added for the purposes of updating name of a second file --PN
+	public String nextFileName2() {
+
+		// Get the next file name
+		Date today = new Date();
+		DateFormat dateFormat = new SimpleDateFormat("yyyyMMdd");
+		String todayString = dateFormat.format(today);
+		String filePrefix = fileNamePrefix2 + todayString;
+		int newFileNum = 0;
+
+		File dir = new File(".");
+		File[] filesList = dir.listFiles();
+
+		for (File file : filesList) {
+			if (file.isFile()) {
+				String fileName = file.getName();
+				if (fileName.matches(filePrefix + "[.]\\d+[.]txt")) {
+					String fileNumString = fileName.substring(
+							fileName.indexOf('.') + 1,
+							fileName.lastIndexOf('.'));
+					int fileNum = Integer.parseInt(fileNumString);
+					if (fileNum >= newFileNum)
+						newFileNum = fileNum + 1;
+
+				}
+			}
+		}
+		return filePrefix + "." + newFileNum + ".txt";
+	}
+	
 	public void customFit(int sector, int layer, int paddle) {
 		// overridden in calibration step class
 	}

--- a/src/main/java/org/jlab/calib/services/cnd/CNDEffVEventListener.java
+++ b/src/main/java/org/jlab/calib/services/cnd/CNDEffVEventListener.java
@@ -1047,7 +1047,7 @@ public class CNDEffVEventListener extends CNDCalibrationEngine {
 				for (int j=0; j<calib.getColumnCount(); j++) {
 					if (writeCols[j] == 1 || writeCols[j] == 2) {
 						line = line+calib.getValueAt(i, j);
-						if (j<calib.getColumnCount()-1) {
+						if (j<calib.getColumnCount()-1 && j != 6) { //hard code exception to stop whitespace being added at the end of each row of EffV file --PN
 							line = line+" ";
 						}
 					}

--- a/src/main/java/org/jlab/calib/services/cnd/CNDEffVEventListener.java
+++ b/src/main/java/org/jlab/calib/services/cnd/CNDEffVEventListener.java
@@ -129,7 +129,7 @@ public class CNDEffVEventListener extends CNDCalibrationEngine {
 
 	public CNDEffVEventListener() {
 
-		stepName = "EffV";
+		stepName = "EffV, Uturn-Loss & LR-Adj.";
 		fileNamePrefix = "CND_CALIB_EFFV_";
 		fileNamePrefix2 = "CND_CALIB_UTURNTLOSS_";
 		// get file name here so that each timer update overwrites it

--- a/src/main/java/org/jlab/calib/services/cnd/CNDEnergy.java
+++ b/src/main/java/org/jlab/calib/services/cnd/CNDEnergy.java
@@ -1437,7 +1437,7 @@ public class CNDEnergy extends CNDCalibrationEngine{
 				for (int j=0; j<calib.getColumnCount(); j++) {
 					if (writeCols[j] == 1 || writeCols[j] == 2) {
 						line = line+calib.getValueAt(i, j);
-						if (j<calib.getColumnCount()-1) {
+						if (j<calib.getColumnCount()-1 && j != 6) { //hard code exception to stop whitespace being added at the end of each row of Att' file --PN
 							line = line+" ";
 						}
 					}

--- a/src/main/java/org/jlab/calib/services/cnd/CNDEnergy.java
+++ b/src/main/java/org/jlab/calib/services/cnd/CNDEnergy.java
@@ -126,7 +126,7 @@ public class CNDEnergy extends CNDCalibrationEngine{
 		filename = nextFileName();
 
 		calib = new CalibrationConstants(3,
-				"mip_dir_L/F:mip_dir_L_err/F:mip_indir_L/F:mip_indir_L_err/F:mip_dir_R/F:mip_dir_R_err/F:mip_indir_R/F:mip_indir_R_err/F");
+				"mip_dir_L/F:mip_dir_L_err/F:mip_indir_L/F:mip_indir_L_err/F:mip_dir_R/F:mip_dir_R_err/F:mip_indir_R/F:mip_indir_R_err/F:attlen_L/F:attlen_L_err/F:attlen_R/F:attlen_R_err/F");
 		calib.setName("/calibration/cnd/Energy");
 		calib.setPrecision(5);
 	}
@@ -1303,6 +1303,68 @@ public class CNDEnergy extends CNDCalibrationEngine{
 		return MIPindirRight;
 	}
 
+	public Double getAttLenLeft(int sector, int layer, int component) {
+
+		double attLenLeft = 0.0;
+		double overrideVal = constants.getItem(sector, layer, component)[OVERRIDE_LEFT];
+
+		if (overrideVal != UNDEFINED_OVERRIDE) {
+			attLenLeft = overrideVal;
+		} else {
+			double gradient = dataGroups.getItem(sector, layer, component).getF1D("funcLdir").getParameter(1);
+			attLenLeft = -2. / gradient;
+		}
+		return attLenLeft;
+	}
+
+	public Double getAttLenLeftError(int sector, int layer, int component) {
+
+		double attLenLeft = 0.0;
+		double attLenLefterror = 0.0;
+		double overrideVal = constants.getItem(sector, layer, component)[OVERRIDE_LEFT];
+
+		if (overrideVal != UNDEFINED_OVERRIDE) {
+			attLenLeft = overrideVal;
+		} else {
+			double gradient = dataGroups.getItem(sector, layer, component).getF1D("funcLdir").getParameter(1);
+			double gradienterror = dataGroups.getItem(sector, layer, component).getF1D("funcLdir").parameter(1).error();
+			attLenLeft = -2. / gradient;
+			attLenLefterror = gradienterror*attLenLeft*attLenLeft/2.;
+		}
+		return attLenLefterror;
+	}
+
+	public Double getAttLenRight(int sector, int layer, int component) {
+
+		double attLenRight = 0.0;
+		double overrideVal = constants.getItem(sector, layer, component)[OVERRIDE_RIGHT];
+
+		if (overrideVal != UNDEFINED_OVERRIDE) {
+			attLenRight = overrideVal;
+		} else {
+			double gradient = dataGroups.getItem(sector, layer, component).getF1D("funcRdir").getParameter(1);
+			attLenRight = -2. / gradient;
+		}
+		return attLenRight;
+	}
+
+	public Double getAttLenRightError(int sector, int layer, int component) {
+
+		double attLenRight = 0.0;
+		double attLenRighterror = 0.0;
+		double overrideVal = constants.getItem(sector, layer, component)[OVERRIDE_RIGHT];
+
+		if (overrideVal != UNDEFINED_OVERRIDE) {
+			attLenRight = overrideVal;
+		} else {
+			double gradient = dataGroups.getItem(sector, layer, component).getF1D("funcRdir").getParameter(1);
+			double gradienterror = dataGroups.getItem(sector, layer, component).getF1D("funcRdir").parameter(1).error();
+			attLenRight = -2. / gradient;
+			attLenRighterror = gradienterror* attLenRight* attLenRight/2.;
+		}
+		return attLenRighterror;
+	}
+	
 	@Override
 	public void saveRow(int sector, int layer, int component) {
 
@@ -1322,6 +1384,14 @@ public class CNDEnergy extends CNDCalibrationEngine{
 				"mip_indir_R", sector, layer, component);
 		calib.setDoubleValue(ALLOWED_DIFF,
 				"mip_indir_R_err", sector, layer, component);
+		calib.setDoubleValue(getAttLenLeft(sector, layer, component),
+				"attlen_L", sector, layer, component);
+		calib.setDoubleValue(getAttLenLeftError(sector, layer, component),
+				"attlen_L_err", sector, layer, component);
+		calib.setDoubleValue(getAttLenRight(sector, layer, component),
+				"attlen_R", sector, layer, component);
+		calib.setDoubleValue(getAttLenRightError(sector, layer, component),
+				"attlen_R_err", sector, layer, component);
 	}
 
 	@Override

--- a/src/main/java/org/jlab/calib/services/cnd/CNDEnergy.java
+++ b/src/main/java/org/jlab/calib/services/cnd/CNDEnergy.java
@@ -123,7 +123,7 @@ public class CNDEnergy extends CNDCalibrationEngine{
 
 	public CNDEnergy() {
 
-		stepName = "ADC-to-Energy conversion";
+		stepName = "Attenuation & ADC-to-Energy Conversion";
 		fileNamePrefix = "CND_CALIB_Energy_";
 		fileNamePrefix2 = "CND_CALIB_ATTENUATION_"; // --PN
 		// get file name here so that each timer update overwrites it

--- a/src/main/java/org/jlab/calib/services/cnd/CNDTimeOffsetslayerEventListener.java
+++ b/src/main/java/org/jlab/calib/services/cnd/CNDTimeOffsetslayerEventListener.java
@@ -187,9 +187,11 @@ public class CNDTimeOffsetslayerEventListener extends CNDCalibrationEngine {
 		}
 		if(CNDCalibration.mintime!=0.0){
 			HIST_X_MIN =CNDCalibration.mintime;
+			System.out.println("MIN VALUE SEEN INSIDE GLOB::resetEventListener() : " + CNDCalibration.mintime);
 		}
-		if(CNDCalibration.maxtimeLR!=0.0){
+		if(CNDCalibration.maxtime!=0.0){
 			HIST_X_MAX =CNDCalibration.maxtime;
+			System.out.println("MAX VALUE SEEN INSIDE GLOB::resetEventListener() : " + CNDCalibration.maxtime);
 		}
 
         // GM perform init processing


### PR DESCRIPTION
The CND Calibration suite repo was forked in order to combine a couple of steps of the calibration, as they relied on the same fitted graphs, as well as the same previously calibrated constants.

Steps which were combined are:

    Effective Velocity & LR_adjusted/uturn_tloss
    Attenuation & ADC-to-Energy

This has been tested against the previously circulated .jar and outputs the same constants (when using the same runf-file&fit-limits, and writes out identical constant files for upload to the ccdb. 
